### PR TITLE
AppLauncher: Be less verbose in Categories

### DIFF
--- a/desktop-integration/app-launcher.md
+++ b/desktop-integration/app-launcher.md
@@ -68,7 +68,6 @@ The full list of supported categories can be found in the FreeDesktop.Org [menu 
 You can add more than one category to your app launcher file and you should add all that apply
 {% endhint %}
 
-
 ## Keywords
 
 You may also include keywords in your launcher to help users find your app via search. These follow [the "Keywords" key](https://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html) in your .desktop file. For example, a web browser might include "Internet" as a keyword even though it's not in the app's name, generic name, or description. As a result, a user searching for "Internet" will find the app. Here are some more examples:

--- a/desktop-integration/app-launcher.md
+++ b/desktop-integration/app-launcher.md
@@ -56,29 +56,18 @@ Comment=Listen to music
 
 ## Categories
 
-The following categories may be used to aid with searching or browsing for your app. Keep in mind that you can add more than one and you should add all that apply:
-
-* AudioVideo
-* Audio
-* Video
-* Development
-* Education
-* Game
-* Graphics
-* Network
-* Office
-* Science
-* Settings
-* System
-* Utility
-
-For more info, see the FreeDesktop.Org [menu entry](https://specifications.freedesktop.org/menu-spec/latest/apa.html) spec and the [list of additional categories](https://standards.freedesktop.org/menu-spec/latest/apas02.html)
-
-Categories should be separated by and terminated with a semicolon:
+Categories are used to sort your app in AppCenter and in the applications menu. In your app launcher file, they should be separated by and terminated with a semicolon:
 
 ```text
 Categories=Graphics;Photography;Viewer;
 ```
+
+The full list of supported categories can be found in the FreeDesktop.Org [menu entry](https://specifications.freedesktop.org/menu-spec/latest/apa.html) specification and the [list of additional categories](https://standards.freedesktop.org/menu-spec/latest/apas02.html)
+
+{% hint style="info" %}
+You can add more than one category to your app launcher file and you should add all that apply
+{% endhint %}
+
 
 ## Keywords
 


### PR DESCRIPTION
* Be more explicit about where categories are used
* Skip listing the categories since we link to the spec with more explanation about what the categories mean
* Add the part about more than one category to a hint block