### PR TITLE
docs: add templates for icons

### DIFF
--- a/.gitbook/assets/128-template.svg
+++ b/.gitbook/assets/128-template.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 128 128"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     units="px"
+     width="256px"
+     showguides="true">
+    <sodipodi:guide
+       position="0,9"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,113"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,64"
+       orientation="0,1"/>
+  </sodipodi:namedview>
+</svg>

--- a/.gitbook/assets/16-template.svg
+++ b/.gitbook/assets/16-template.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     units="px"
+     width="16px"
+     showguides="true">
+    <sodipodi:guide
+       position="0,1"
+       orientation="0,-1"/>
+    <sodipodi:guide
+       position="0,15"
+       orientation="0,-1"/>
+    <sodipodi:guide
+       position="0,8"
+       orientation="0,1"/>
+  </sodipodi:namedview>
+</svg>

--- a/.gitbook/assets/24-template.svg
+++ b/.gitbook/assets/24-template.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     units="px"
+     width="24px"
+     showguides="true">
+    <sodipodi:guide
+       position="0,2"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,22"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,12"
+       orientation="0,1"/>
+  </sodipodi:namedview>
+</svg>

--- a/.gitbook/assets/32-template.svg
+++ b/.gitbook/assets/32-template.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="32"
+   height="32"
+   viewBox="0 0 32 32"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     units="px"
+     width="256px"
+     showguides="true">
+    <sodipodi:guide
+       position="0,2"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,28"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,16"
+       orientation="0,1"/>
+  </sodipodi:namedview>
+</svg>

--- a/.gitbook/assets/48-template.svg
+++ b/.gitbook/assets/48-template.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     units="px"
+     width="48px"
+     showguides="true">
+    <sodipodi:guide
+       position="0,3"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,43"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,24"
+       orientation="0,1"/>
+  </sodipodi:namedview>
+</svg>

--- a/.gitbook/assets/64-template.svg
+++ b/.gitbook/assets/64-template.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 64 64"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     units="px"
+     width="256px"
+     showguides="true">
+    <sodipodi:guide
+       position="0,4"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,60"
+       orientation="0,1"/>
+    <sodipodi:guide
+       position="0,32"
+       orientation="0,1"/>
+  </sodipodi:namedview>
+</svg>

--- a/reference/iconography.md
+++ b/reference/iconography.md
@@ -94,14 +94,14 @@ Keeping these lines in mind while designing, means you can place elements along 
 
 If you're designing a square-shaped icon, like the one for Terminal seen above, then consider using these common measurements \(in pixels\) for each icon:
 
-| Canvas Size | Base Line | x-Height | Mean Line Height |
-| :--- | :--- | :--- | :--- |
-| 16x16 | 1 | 14 | 8 |
-| 24x24 | 2 | 20 | 12 |
-| 32x32 | 2 | 26 | 16 |
-| 48x48 | 3 | 40 | 24 |
-| 64x64 | 4 | 56 | 32 |
-| 128x128 | 9 | 104 | 64 |
+| Canvas Size | Base Line | x-Height | Mean Line Height | Template|
+| :--- | :--- | :--- | :--- | :--- |
+| 16x16 | 1 | 14 | 8 | [16-template.svg](../.gitbook/assets/16-template.svg) |
+| 24x24 | 2 | 20 | 12 | [24-template.svg](../.gitbook/assets/24-template.svg) |
+| 32x32 | 2 | 26 | 16 | [32-template.svg](../.gitbook/assets/32-template.svg) |
+| 48x48 | 3 | 40 | 24 | [48-template.svg](../.gitbook/assets/48-template.svg) |
+| 64x64 | 4 | 56 | 32 | [64-template.svg](../.gitbook/assets/64-template.svg) |
+| 128x128 | 9 | 104 | 64 | [128-template.svg](../.gitbook/assets/128-template.svg) |
 
 ### Exceptions <a id="icon-exceptions"></a>
 


### PR DESCRIPTION
This adds a very basic svg template to the docs, with guides placed at the given positions.